### PR TITLE
use drbd as package name resource

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,7 +2,7 @@ class drbd::service {
   @service { 'drbd':
     ensure  => running,
     enable  => $drbd::service_enable,
-    require => Package['drbd8-utils'],
+    require => Package['drbd'],
     restart => 'service drbd reload',
   }
 }


### PR DESCRIPTION
Otherwise Puppet 4 fails with:

Error 400 on SERVER: Invalid relationship: Service[drbd] { require => Package[drbd8-utils] }, because Package[drbd8-utils] doesn't seem to be in the catalog
