### PR TITLE
Require package drbd in drbd::service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,7 +2,7 @@ class drbd::service {
   @service { 'drbd':
     ensure  => running,
     enable  => $drbd::service_enable,
-    require => Package['drbd8-utils'],
+    require => Package['drbd'],
     restart => 'service drbd reload',
   }
 }


### PR DESCRIPTION
The drbd class aliases the drbd8-utils package to "drbd", so refer to it
by this name in drbd::service.