### PR TITLE
Add disk parameters support in resources

### DIFF
--- a/manifests/resource.pp
+++ b/manifests/resource.pp
@@ -18,35 +18,37 @@
 #     http://www.drbd.org/users-guide/s-replication-protocols.html
 #  [verify_alg] Algorithm used for block validation on peers. Optional.
 #    Defaults to crc32c. Accepts crc32c, sha1, or md5.
+#  [disk_parameters] Parameters for disk{} section
 #  [manage] If the actual drbd resource shoudl be managed.
 #  [ha_primary] If the resource is being applied on the primary host.
 #  [initial_setup] If this run is associated with the initial setup. Allows a user
 #    to only perform dangerous setup on the initial run.
 define drbd::resource (
-  $host1          = undef,
-  $host2          = undef,
-  $ip1            = undef,
-  $ip2            = undef,
-  $res1           = undef,
-  $res2           = undef,
-  $cluster        = undef,
-  $secret         = false,
-  $port           = '7789',
-  $device         = '/dev/drbd0',
-  $mountpoint     = "/drbd/${name}",
-  $automount      = true,
-  $owner          = 'root',
-  $group          = 'root',
-  $protocol       = 'C',
-  $verify_alg     = 'crc32c',
-  $rate           = false,
-  $net_parameters = false,
-  $manage         = true,
-  $ha_primary     = false,
-  $initial_setup  = false,
-  $fs_type        = 'ext4',
-  $mkfs_opts      = '',
-  $disk           = undef,
+  $host1           = undef,
+  $host2           = undef,
+  $ip1             = undef,
+  $ip2             = undef,
+  $res1            = undef,
+  $res2            = undef,
+  $cluster         = undef,
+  $secret          = false,
+  $port            = '7789',
+  $device          = '/dev/drbd0',
+  $mountpoint      = "/drbd/${name}",
+  $automount       = true,
+  $owner           = 'root',
+  $group           = 'root',
+  $protocol        = 'C',
+  $verify_alg      = 'crc32c',
+  $rate            = false,
+  $disk_parameters = false,
+  $net_parameters  = false,
+  $manage          = true,
+  $ha_primary      = false,
+  $initial_setup   = false,
+  $fs_type         = 'ext4',
+  $mkfs_opts       = '',
+  $disk            = undef,
 ) {
   include ::drbd
 

--- a/templates/header.res.erb
+++ b/templates/header.res.erb
@@ -24,4 +24,12 @@ resource <%= @name %> {
     rate <%= @rate %>;
 <% end -%>
   }
+<% if @disk_parameters -%>
+
+  disk {
+<% @disk_parameters.sort_by {|k, v| k}.each do |k, v| -%>
+    <%= k %> <%= v %>;
+<% end -%>
+  }
+<% end -%>
 


### PR DESCRIPTION
With this PR, module user will be able to set disk parameters inside resource definition.

Example is:

```
  drbd::resource { 'meta1':
    ...
    ...
    ...
    disk_parameters => {
      'c-plan-ahead' => '0',
      'c-max-rate'   => '200M',
      'c-min-rate'   => '100M',
      'resync-rate'  => '200M',
    },
    ...
  }
```

This will generate the following section inside the resource file:

```
  disk {
    c-max-rate 200M;
    c-min-rate 100M;
    c-plan-ahead 0;
    resync-rate 200M;
  }
```