### PR TITLE
Fix package names with hiera / Add Debian 8/9/10 support

### DIFF
--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -1,0 +1,4 @@
+---
+# Debian family configuration
+
+drbd::package_name: 'drbd-utils'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,14 @@
+---
+version: 5
+
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+
+hierarchy:
+  - name: 'module drbd: Major OS Version'
+    path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
+
+  - name: 'module drbd: OS family'
+    path: '%{facts.os.family}-family.yaml'
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,9 +5,9 @@
 # by an example created by Rackspace's cloudbuilders
 #
 class drbd(
-  $service_enable                                         = true,
+  Boolean                                 $service_enable = true,
   Enum['running', 'stopped', 'unmanaged'] $service_ensure = running,
-  $package_name                                           = 'drbd8-utils',
+  String                                  $package_name   = 'drbd8-utils',
 ) {
   include drbd::service
 

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,14 @@
       "operatingsystemrelease": [
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9",
+        "10"
+      ]
     }
   ],
   "dependencies": [

--- a/spec/classes/drbd_spec.rb
+++ b/spec/classes/drbd_spec.rb
@@ -1,14 +1,34 @@
 require 'spec_helper'
 
 describe 'drbd', type: :class do
-  it { is_expected.to contain_class('drbd::service') }
-  it { is_expected.to contain_package('drbd') }
-  it { is_expected.to contain_exec('modprobe drbd') }
-  it { is_expected.to contain_file('/drbd') }
-  it { is_expected.to contain_file('/etc/drbd.conf') }
-  it { is_expected.to contain_file('/etc/drbd.d').with_ensure('directory').with_purge(true) }
-  it do
-    is_expected.to contain_file('/etc/drbd.d/global_common.conf').with_content %r{usage-count no;$}
-    is_expected.to contain_file('/etc/drbd.d/global_common.conf').with_content %r{protocol C;$}
+
+  shared_examples 'drbd shared example' do
+    it { is_expected.to compile.with_all_deps }
+
+    it { is_expected.to contain_class('drbd::service') }
+    it { is_expected.to contain_exec('modprobe drbd') }
+    it { is_expected.to contain_file('/drbd') }
+    it { is_expected.to contain_file('/etc/drbd.conf') }
+    it { is_expected.to contain_file('/etc/drbd.d').with_ensure('directory').with_purge(true) }
+    it do
+      is_expected.to contain_file('/etc/drbd.d/global_common.conf').with_content %r{usage-count no;$}
+      is_expected.to contain_file('/etc/drbd.d/global_common.conf').with_content %r{protocol C;$}
+    end
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+        it_behaves_like 'drbd shared example'
+
+        it do
+          if (facts[:osfamily] == 'Debian')
+            is_expected.to contain_package('drbd').with_name('drbd-utils')
+          else
+            is_expected.to contain_package('drbd').with_name('drbd8-utils')
+          end
+        end
+    end
   end
 end

--- a/spec/classes/drbd_spec.rb
+++ b/spec/classes/drbd_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'drbd', type: :class do
-
   shared_examples 'drbd shared example' do
     it { is_expected.to compile.with_all_deps }
 
@@ -20,15 +19,15 @@ describe 'drbd', type: :class do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-        it_behaves_like 'drbd shared example'
+      it_behaves_like 'drbd shared example'
 
-        it do
-          if (facts[:osfamily] == 'Debian')
-            is_expected.to contain_package('drbd').with_name('drbd-utils')
-          else
-            is_expected.to contain_package('drbd').with_name('drbd8-utils')
-          end
+      it do
+        if facts[:osfamily] == 'Debian'
+          is_expected.to contain_package('drbd').with_name('drbd-utils')
+        else
+          is_expected.to contain_package('drbd').with_name('drbd8-utils')
         end
+      end
     end
   end
 end


### PR DESCRIPTION
There seems to be a lot of discussions about package names ...
.. so I just add another (modern) solution using hiera.

I use this module with Debian, so I know its working with this addition in buster (10), stretch (9) and jessie (8). 