### PR TITLE
fix metadisk parameter

### DIFF
--- a/manifests/resource.pp
+++ b/manifests/resource.pp
@@ -62,7 +62,7 @@ define drbd::resource (
   $fs_type                                                    = 'ext4',
   $mkfs_opts                                                  = '',
   $disk                                                       = undef,
-  String $metadisk                                            = 'internal',
+  String[1] $metadisk                                         = 'internal',
   Optional[String] $flexible_metadisk                         = undef,
 ) {
   include drbd

--- a/manifests/resource.pp
+++ b/manifests/resource.pp
@@ -63,7 +63,7 @@ define drbd::resource (
   $mkfs_opts                                                  = '',
   $disk                                                       = undef,
   String[1] $metadisk                                         = 'internal',
-  Optional[String] $flexible_metadisk                         = undef,
+  Optional[String[1]] $flexible_metadisk                      = undef,
 ) {
   include drbd
 

--- a/manifests/resource.pp
+++ b/manifests/resource.pp
@@ -12,6 +12,9 @@
 #     name of the disk will be the same on both hosts. Required.
 #  [metadisk] Name of the metadisk. Allows to use an external metadisk. Assumes
 #     that the name of the metadisk will be the same on both hosts. Defaults to internal
+#     this parameter is ignored if flexible_metadisk is defined
+#  [flexible_metadisk] Name of the flexible_metadisk
+#     defaults to undef. If defined, the metadisk parameter is superseeded
 #  [secret] The shared secret used in peer authentication.. False indicates that
 #    no secret be required. Optional. Defaults to false.
 #  [port] Port which drbd will use for replication on both hosts.
@@ -59,7 +62,8 @@ define drbd::resource (
   $fs_type                                                    = 'ext4',
   $mkfs_opts                                                  = '',
   $disk                                                       = undef,
-  String[1] $metadisk                                         = 'internal',
+  String $metadisk                                            = 'internal',
+  Optional[String] $flexible_metadisk                         = undef,
 ) {
   include drbd
 

--- a/spec/defines/resource_spec.rb
+++ b/spec/defines/resource_spec.rb
@@ -51,7 +51,7 @@ describe 'drbd::resource', type: :define do
   end
 
   context 'DRBD metadisk' do
-    describe 'defaults to internalr' do
+    describe 'defaults to internal' do
       let(:params) do
         default_params
       end
@@ -59,13 +59,13 @@ describe 'drbd::resource', type: :define do
       it_behaves_like 'drbd::resource generic example'
 
       it {
-        is_expected.to contain_concat__fragment('mock_drbd_resource drbd header').with_content(%r{^\s*flexible-meta-disk internal;$})
+        is_expected.to contain_concat__fragment('mock_drbd_resource drbd header').with_content(%r{^\s*meta-disk internal;$})
       }
     end
-    describe 'set external metadisk' do
+    describe 'set external flexible metadisk' do
       let(:params) do
         {
-          metadisk: '/dev/vg00/drbd-meta[0]'
+          flexible_metadisk: '/dev/vg00/drbd-meta[0]'
         }.merge(default_params)
       end
 

--- a/templates/header.res.erb
+++ b/templates/header.res.erb
@@ -3,7 +3,11 @@ resource <%= @name %> {
   protocol  <%= @protocol %>;
   device    <%= @device %>;
   disk      <%= @disk %>;
-  flexible-meta-disk <%= @metadisk %>;
+<% if @flexible_metadisk -%>
+  flexible-meta-disk <%= @flexible_metadisk %>;
+<% else -%>
+  meta-disk <%= @metadisk %>;
+<% end -%>
 
 <% unless @handlers_parameters.empty?  -%>
 


### PR DESCRIPTION
in commit aad63cc6cc995745f4ac3440a9654e256bd473be
the meta-disk switched to flexible-meta-disk.
For internal metadisk, the two options are equal, but for
external disk this can brak the configuration.

This commit adds the possibility to configure a flexible-metadisk
by not breaking existing configs.

This commit is backwards compatible with the last tagged version 0.5.2
but breaks compatibility with actual master.