### PR TITLE
fix resource not defined in your config (for this host) for fqdn

### DIFF
--- a/templates/resource.res.erb
+++ b/templates/resource.res.erb
@@ -1,3 +1,3 @@
-  on <%= @hostname %> {
+  on <%= @fqdn %> {
     address <%= @ipaddress %>:<%= @port %>;
   }


### PR DESCRIPTION
#### Pull Request (PR) description
Currently the template resource.res.erb uses @hostname variable which produces short hostname. It's crucial for DRBD to have node names in resource configs exactly as they appear in hostname/uname -n commands output. In case a host has its name set in FQDN format these commands give full hostnames including domain part. As a result we have the error like:
'r0' not defined in your config (for this host)
because resource config contains short names.

I suggest to use @fqdn variable which fixes the problem and it gracefully fails back to shortname if there's no domain part in hostname. 

#### This Pull Request (PR) fixes the following issues
N/A