### PR TITLE
Define package name for RedHat family.

### DIFF
--- a/data/RedHat-family.yaml
+++ b/data/RedHat-family.yaml
@@ -1,0 +1,4 @@
+---
+# RedHat family configuration
+
+drbd::package_name: 'drbd-utils'

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,34 @@
       ]
     },
     {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "11",

--- a/spec/classes/drbd_spec.rb
+++ b/spec/classes/drbd_spec.rb
@@ -25,7 +25,7 @@ describe 'drbd', type: :class do
       it_behaves_like 'drbd shared example'
 
       it do
-        if facts[:os]['family'] == 'Debian'
+        if facts[:os]['family'] == 'Debian' || facts[:os]['family'] == 'RedHat'
           is_expected.to contain_package('drbd').with_name('drbd-utils')
         else
           is_expected.to contain_package('drbd').with_name('drbd8-utils')


### PR DESCRIPTION
Add RedHat family DRBD package name. The package name was checked for AlmaLinux 8 and AlmaLinux 9.